### PR TITLE
[Fix] 'react-dom/clien' 에러

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom/client';
+import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import store from 'redux/store';
 import App from 'App';


### PR DESCRIPTION
에러코드에서 설명해주듯이,

index.js 파일에서 react-dom/client 모듈을 찾을 수 없기 때문에 발생한 문제다.

 

react-dom/client 는 v18에서 새로 생긴 모듈이다.

React v18 버전부터는 이 모듈을 이용해 DOM을 렌더링 한다.

 

React v18 이전 버전은 다른 모듈(react-dom)을 사용하여 렌더링 한다.

이걸 회귀 시켜주면 된다.